### PR TITLE
Better support for binaries, on Linux

### DIFF
--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -23,10 +23,12 @@ available_packages <- function(contriburl = contrib.url(repos, type),
 
   update_repo_metadata(contriburl)
 
+  mytype <- if (missing(type) || type == "both") "source" else type
+
   call <- match.call()
   call[[1]] <- quote(utils::available.packages)
   call$repos <-
-    if (is.null(repos)) NULL else c(get_crancache_repos(), repos)
+    if (is.null(repos)) NULL else c(get_crancache_repos(mytype), repos)
   call$filters <- list()
 
   res <- eval(call, envir = parent.frame())

--- a/R/cache-dir.R
+++ b/R/cache-dir.R
@@ -76,12 +76,8 @@ get_cache_urls <- function(type = "both") {
 #' @importFrom utils contrib.url
 
 get_package_dirs <- function(root, type) {
-  if (identical(type, "localplatform")) {
-    paste0(root, "/bin/localplatform")
-  } else {
-    paste0(
-      root,
-      vapply(type, contrib.url, "", repos = "")
-    )
-  }
+  paste0(
+    root,
+    vapply(type, contrib.url, "", repos = "")
+  )
 }

--- a/R/cache-dir.R
+++ b/R/cache-dir.R
@@ -33,38 +33,55 @@ get_cache_dir <- function() {
 
 get_cache_package_dirs <- function() {
   cache_dir <- get_cache_dir()
+
   cran <- file.path(cache_dir, "cran")
   bioc <- file.path(cache_dir, "bioc")
   other <- file.path(cache_dir, "other")
+
+  cran_bin <- file.path(cache_dir, "cran-bin")
+  bioc_bin <- file.path(cache_dir, "bioc-bin")
+  other_bin <- file.path(cache_dir, "other-bin")
+
   c(
-    "cran/platform"  = get_package_dirs(cran, .Platform$pkgType),
-    "cran/source"    = get_package_dirs(cran, "source"),
-    "bioc/platform"  = get_package_dirs(bioc, .Platform$pkgType),
-    "bioc/source"    = get_package_dirs(bioc, "source"),
-    "other/platform" = get_package_dirs(other, .Platform$pkgType),
-    "other/source"   = get_package_dirs(other, "source")
+    "cran-bin/source"     = get_package_dirs(cran_bin, "source"),
+    "cran/platform"       = get_package_dirs(cran, .Platform$pkgType),
+    "cran/source"         = get_package_dirs(cran, "source"),
+    "bioc-bin/source"     = get_package_dirs(bioc_bin, "source"),
+    "bioc/platform"       = get_package_dirs(bioc, .Platform$pkgType),
+    "bioc/source"         = get_package_dirs(bioc, "source"),
+    "other-bin/source"    = get_package_dirs(other_bin, "source"),
+    "other/platform"      = get_package_dirs(other, .Platform$pkgType),
+    "other/source"        = get_package_dirs(other, "source")
   )
 }
 
 #' @importFrom utils URLencode
 
-get_cache_urls <- function() {
-  paths <- paste0(
-    "file://",
-    get_cache_dir(),
-    c("/cran", "/bioc", "/other")
-  )
+get_cache_urls <- function(type = "both") {
+
+  repo_names <- if (type == "both" || type == "binary" ||
+                    grepl("^mac.binary", type) || grepl("win.binary", type)) {
+    c("cran-bin", "cran", "bioc-bin", "bioc", "other-bin", "other")
+  } else {
+    c("cran", "bioc", "other")
+  }
+
+  paths <- paste0("file://", get_cache_dir(), "/", repo_names)
   structure(
     vapply(paths, URLencode, character(1), USE.NAMES = FALSE),
-    names = c("cran", "bioc", "other")
+    names = repo_names
   )
 }
 
 #' @importFrom utils contrib.url
 
 get_package_dirs <- function(root, type) {
-  paste0(
-    root,
-    vapply(type, contrib.url, "", repos = "")
-  )
+  if (identical(type, "localplatform")) {
+    paste0(root, "/bin/localplatform")
+  } else {
+    paste0(
+      root,
+      vapply(type, contrib.url, "", repos = "")
+    )
+  }
 }

--- a/R/download-packages.R
+++ b/R/download-packages.R
@@ -25,7 +25,10 @@ download_packages <- function(
 
   update_repo_metadata(contriburl)
 
-  myrepos <- c(get_crancache_repos(), repos)
+  ## download.packages defaults to source packages if
+  ## type is not specified explicitly
+  mytype <- if (missing(type)) "source" else type
+  myrepos <- c(get_crancache_repos(type = mytype), repos)
 
   if (should_update_crancache()) on.exit(update_cache(destdir))
 

--- a/R/install-packages.R
+++ b/R/install-packages.R
@@ -49,7 +49,8 @@ install_packages <- function(
   myrepos <- if (is.null(repos)) {
     NULL
   } else {
-    c(get_crancache_repos(), repos)
+    mytype <- if (missing(type)) "binary" else type
+    c(get_crancache_repos(type = mytype), repos)
   }
 
   warnings <- list()

--- a/R/is_active.R
+++ b/R/is_active.R
@@ -3,7 +3,7 @@ is_crancache_active <- function() {
   Sys.getenv("CRANCACHE_DISABLE", "") == ""
 }
 
-get_crancache_repos <- function() {
+get_crancache_repos <- function(type) {
 
   if (!is_crancache_active()) return(character())
 
@@ -17,7 +17,7 @@ get_crancache_repos <- function() {
     unique(trimws(strsplit(repos, ",", fixed = TRUE)[[1]]))
   }
 
-  crancache_repos <- get_cached_repos()
+  crancache_repos <- get_cached_repos(type)
 
   if (isTRUE(use_cache)) {
     use_cache <- rep(TRUE, length(crancache_repos))

--- a/R/repos.R
+++ b/R/repos.R
@@ -9,9 +9,9 @@ interpret_type <- function(type) {
   }
 }
 
-get_cached_repos <- function() {
+get_cached_repos <- function(type) {
   create_cache_if_needed()
-  get_cache_urls()
+  get_cache_urls(type)
 }
 
 #' @importFrom cranlike create_empty_PACKAGES

--- a/R/update-cache.R
+++ b/R/update-cache.R
@@ -76,12 +76,14 @@ get_cache_dir_for_file <- function(file) {
   repository <- desc_get("Repository", file)[[1]]
   biocViews <- desc_get("biocViews", file)[[1]]
 
+  linux_binary <- !grepl("[-0-9.]+\\.tar\\.gz$", file)
+
   prefix <- if (identical(repository, "CRAN")) {
-    "cran/"
+    if (linux_binary) "cran-bin/" else "cran/"
   } else if (!is.na(biocViews)) {
-    "bioc/"
+    if (linux_binary) "bioc-bin/" else "bioc/"
   } else {
-    "other/"
+    if (linux_binary) "other-bin/" else "other/"
   }
 
   which <- if (grepl("\\.zip$", file)) {
@@ -95,6 +97,7 @@ get_cache_dir_for_file <- function(file) {
     }
 
   } else if (grepl("\\.tar\\.gz$", file)) {
+    ## This also includes Linux binaries
     "source"
   }
 

--- a/R/update-packages.R
+++ b/R/update-packages.R
@@ -29,7 +29,8 @@ update_packages <- function(
 
   update_repo_metadata(contriburl)
 
-  myrepos <- c(get_crancache_repos(), repos)
+  mytype <- if (missing(type)) "binary" else type
+  myrepos <- c(get_crancache_repos(mytype), repos)
 
   warnings <- list()
   errors <- list()


### PR DESCRIPTION
In particular, we put the locally built binary packages
in completely separate repos, and only add these repos
to the repo list if binaries are considered.

They are used by default for install_packages() and
update_packages(), but not for download_packages() and
available_packages().

Fixes #21.